### PR TITLE
story/reusable-typography-components

### DIFF
--- a/apps/web/common/components/ui/Typography.tsx
+++ b/apps/web/common/components/ui/Typography.tsx
@@ -12,28 +12,30 @@ const typographyVariants = cva("font-bold", {
       h5: "text-sm font-bold",
       h6: "text-xs font-bold",
     },
-    fontWeight:{
-        normal:"font-normal",
-        bold:"font-bold",
-        thin:"font-thin",
-        semiBold:"font-semibold",
-    }
+    fontWeight: {
+      normal: "font-normal",
+      bold: "font-bold",
+      thin: "font-thin",
+      semiBold: "font-semibold",
+    },
   },
   defaultVariants: {
     variant: "p",
-    fontWeight:"normal"
+    fontWeight: "normal",
   },
 })
 export interface TypographyProps
   extends React.DetailsHTMLAttributes<HTMLDivElement>,
     VariantProps<typeof typographyVariants> {
-        children: string
-    }
+  children: string
+}
 
 const Typography = React.forwardRef<HTMLDivElement, TypographyProps>(
   ({ variant, fontWeight, className, children }) => {
     return (
-      <p className={cn(typographyVariants({ variant, fontWeight, className}))}>{children}</p>
+      <p className={cn(typographyVariants({ variant, fontWeight, className }))}>
+        {children}
+      </p>
     )
   }
 )

--- a/apps/web/common/components/ui/Typography.tsx
+++ b/apps/web/common/components/ui/Typography.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import { cn } from "@/common/helpers/cn"
+import { VariantProps, cva } from "class-variance-authority"
+const typographyVariants = cva("font-bold", {
+  variants: {
+    variant: {
+      p: "text-base",
+      h1: "text-3xl font-bold",
+      h2: "text-2xl font-bold",
+      h3: "text-xl font-bold",
+      h4: "text-lg font-bold",
+      h5: "text-sm font-bold",
+      h6: "text-xs font-bold",
+    },
+    fontWeight:{
+        normal:"font-normal",
+        bold:"font-bold",
+        thin:"font-thin",
+        semiBold:"font-semibold",
+    }
+  },
+  defaultVariants: {
+    variant: "p",
+    fontWeight:"normal"
+  },
+})
+export interface TypographyProps
+  extends React.DetailsHTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof typographyVariants> {
+        children: string
+    }
+
+const Typography = React.forwardRef<HTMLDivElement, TypographyProps>(
+  ({ variant, fontWeight, className, children }) => {
+    return (
+      <p className={cn(typographyVariants({ variant, fontWeight, className}))}>{children}</p>
+    )
+  }
+)
+Typography.displayName = "Typography"
+
+export { Typography, typographyVariants }


### PR DESCRIPTION
### What?

Created reusable component for typography

### Why?

To make all the paragraph and headers in same component

### Other Comments

\_Provide elaboration or other comments that you need to note (optional)

### Screenshots or Video

![Screenshot 2023-09-09 120317](https://github.com/explore-siargao/explore-siargao/assets/29083384/cff0c1a1-4de3-4198-8f6c-1ea5f9ca6cf4)
![Screenshot 2023-09-10 205756](https://github.com/explore-siargao/explore-siargao/assets/29083384/364e77a8-b60e-45b8-8023-9a95cea0c88f)

