### PR TITLE
[Task-Story] Disabled previous dates for Calendar

### DIFF
--- a/apps/web/common/components/ui/Calendar.tsx
+++ b/apps/web/common/components/ui/Calendar.tsx
@@ -9,8 +9,11 @@ import { buttonVariants } from "./Button"
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker> & {
   size: "lg" | "md"
-  disabledDays?: Date[] | ((date: Date) => boolean) | { [date: string]: boolean };
-  disabled?: boolean;
+  disabledDays?:
+    | Date[]
+    | ((date: Date) => boolean)
+    | { [date: string]: boolean }
+  disabled?: boolean
 }
 
 function Calendar({

--- a/apps/web/common/components/ui/Calendar.tsx
+++ b/apps/web/common/components/ui/Calendar.tsx
@@ -9,6 +9,8 @@ import { buttonVariants } from "./Button"
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker> & {
   size: "lg" | "md"
+  disabledDays?: Date[] | ((date: Date) => boolean) | { [date: string]: boolean };
+  disabled?: boolean;
 }
 
 function Calendar({

--- a/apps/web/module/Bookings/SingleView/components/ListingDateRangePicker.tsx
+++ b/apps/web/module/Bookings/SingleView/components/ListingDateRangePicker.tsx
@@ -42,7 +42,7 @@ const ListingDateRangePicker = ({ title }: ListingDRProps) => {
           onSelect={(data) => updateDateRange(data as DateRange)}
           numberOfMonths={2}
           size="lg"
-          disabled = {true}
+          disabled={true}
         />
       </div>
       <Button

--- a/apps/web/module/Bookings/SingleView/components/ListingDateRangePicker.tsx
+++ b/apps/web/module/Bookings/SingleView/components/ListingDateRangePicker.tsx
@@ -42,6 +42,7 @@ const ListingDateRangePicker = ({ title }: ListingDRProps) => {
           onSelect={(data) => updateDateRange(data as DateRange)}
           numberOfMonths={2}
           size="lg"
+          disabled = {true}
         />
       </div>
       <Button


### PR DESCRIPTION
### What?

Disabled previous dates for Calendar 

### Why?

When the user picks a date it disables previous dates. The date is still editable in the modal (check-in check-out). It is a story

### Screenshots or Video

![Screenshot (37)](https://github.com/explore-siargao/explore-siargao/assets/107088283/f8c0084f-b111-4552-843f-65cc92b17574)

